### PR TITLE
Add Strength gem

### DIFF
--- a/ThingsToMantain.lua
+++ b/ThingsToMantain.lua
@@ -195,6 +195,7 @@ LIB_OPEN_RAID_GEM_IDS = {
     [173129] = true, --Versatile Jewel Cluster (blue, versatility)
     [173127] = true, --Deadly Jewel Cluster (blue, crit)
     [173128] = true, --Quick Jewel Cluster (blue, haste)
+    [168636] = true, --Leviathan's Eye of Strength (purple, strength)
 }
 
 --/dump GetWeaponEnchantInfo()


### PR DESCRIPTION
I propose adding the +7 strength gem as its recommended by guides (see https://www.icy-veins.com/wow/fury-warrior-pve-dps-gems-enchants-consumables )

I'm working on a WeakAura that lists missing enchants/gems using Details/OpenRaidLib, and this has caused some confusions.

I've also seen some Hunters wearing +7 Agility, but I don't think that is recommended. In any case, those remaining would be:

```
[168637] = true, --Leviathan's Eye of Agility (purple, agility)
[168638] = true, --Leviathan's Eye of Intellect (purple, intellect)
```