### PR TITLE
Add Legs to enchant slots

### DIFF
--- a/ThingsToMantain_Dragonflight.lua
+++ b/ThingsToMantain_Dragonflight.lua
@@ -121,6 +121,7 @@ do
 			[INVSLOT_MAINHAND] = true,
 			[INVSLOT_FEET] = true,
 			[INVSLOT_WRIST] = true,
+			[INVSLOT_LEGS] = true,
 			[INVSLOT_HAND] = false,
 		}
 


### PR DESCRIPTION
There are Int/Str/Agi legs enchants.

Would also be nice if this lib could check for offhand. And missing neck gem slots (need to be 3, because they can simply be added with Medallions)