### PR TITLE
Update LibOpenRaid.lua

### DIFF
--- a/LibOpenRaid.lua
+++ b/LibOpenRaid.lua
@@ -1938,7 +1938,9 @@ end
                 timeLeft, charges, timeOffset, duration, updateTime, auraDuration = openRaidLib.CooldownManager.GetCooldownInfoValues(cooldownInfo)
             end
         end
-
+        if (not timeOffset or not updateTime) then
+            return false, 0, 0, 0, 0, 0, 0, 0
+        end
         return calculatePercent(timeOffset, duration, updateTime, charges)
     end
 
@@ -1955,7 +1957,7 @@ end
     ---@return number duration
     function openRaidLib.GetCooldownStatusFromCooldownInfo(cooldownInfo)
         local timeLeft, charges, timeOffset, duration, updateTime, auraDuration = openRaidLib.CooldownManager.GetCooldownInfoValues(cooldownInfo)
-        if (not timeOffset) then
+        if (not timeOffset or not updateTime) then
             return false, 0, 0, 0, 0, 0, 0, 0
         end
         return calculatePercent(timeOffset, duration, updateTime, charges)


### PR DESCRIPTION
Seems to fix this issue with the interrupts spells giving this error. The error is starting when calling GetCooldownStatusFromCooldownInfo on OnReceiveCooldownUpdate event.

40x ATT/Libs/LibOpenRaid/LibOpenRaid.lua:1906: attempt to perform arithmetic on local 'updateTime' (a nil value)
[string "=(tail call)"]: ?
[string "@ATT/ATT.lua"]:2828: in function `ProcessSync'
[string "@ATT/ATT.lua"]:2860: in function <ATT/ATT.lua:2855>
[string "=[C]"]: in function `xpcall'
[string "@ATT/Libs/LibOpenRaid/LibOpenRaid.lua"]:666: in function `TriggerCallback'
[string "@ATT/Libs/LibOpenRaid/LibOpenRaid.lua"]:2704: in function <ATT/Libs/LibOpenRaid/LibOpenRaid.lua:2673>