### PR TITLE
Add null check on function getMythicPlusMapID for 11.0 compatibility

### DIFF
--- a/LibOpenRaid.lua
+++ b/LibOpenRaid.lua
@@ -2632,9 +2632,11 @@ openRaidLib.commHandler.RegisterComm(CONST_COMM_COOLDOWNREQUEST_PREFIX, openRaid
                 local itemId = GetContainerItemID(backpackId, slotId)
                 if (itemId == LIB_OPEN_RAID_MYTHICKEYSTONE_ITEMID) then
                     local itemLink = GetContainerItemLink(backpackId, slotId)
-                    local destroyedItemLink = itemLink:gsub("|", "")
-                    local color, itemID, mythicPlusMapID = strsplit(":", destroyedItemLink)
-                    return tonumber(mythicPlusMapID)
+                    if (itemLink) then				
+	                local destroyedItemLink = itemLink:gsub("|", "")
+	                local color, itemID, mythicPlusMapID = strsplit(":", destroyedItemLink)
+	                return tonumber(mythicPlusMapID)
+		    end
                 end
             end
         end


### PR DESCRIPTION
The 11.0 pre-patch began throwing an error when attempting to call getMythicPlusMapID() in some situations. Adding a check to ensure itemLink is set before referencing it.

Credit to Nhea from Guilds of WoW for identifying and providing the fix.