### PR TITLE
fix nil error for m+ summary

### DIFF
--- a/LibOpenRaid.lua
+++ b/LibOpenRaid.lua
@@ -3287,8 +3287,8 @@ openRaidLib.commHandler.RegisterComm(CONST_COMM_COOLDOWNREQUEST_PREFIX, openRaid
         --- I really just want this whole thing
         local summary = C_PlayerInfo.GetPlayerMythicPlusRatingSummary("player")
 
-        ratingInfo.currentSeasonScore = summary.currentSeasonScore or 0
-        ratingInfo.runs = summary.runs or {}
+        ratingInfo.currentSeasonScore = summary and summary.currentSeasonScore or 0
+        ratingInfo.runs = summary and summary.runs or {}
         
         local _, _, playerClassID = UnitClass("player")
         ratingInfo.classID = playerClassID


### PR DESCRIPTION
My guildie got this error, in `openRaidLib.KeystoneInfoManager.UpdatePlayerKeystoneInfo` return values of `C_PlayerInfo.GetPlayerMythicPlusRatingSummary` are properly checked so we have to do it here as well
```
4x ...ddOns/ExRT_Reminder/Libs/LibOpenRaid/LibOpenRaid.lua:3290: attempt to index local 'summary' (a nil value)
[ExRT_Reminder/Libs/LibOpenRaid/LibOpenRaid.lua]:3315: in function <...ddOns/ExRT_Reminder/Libs/LibOpenRaid/LibOpenRaid.lua:3312>
[ExRT_Reminder/Libs/LibOpenRaid/LibOpenRaid.lua]:3344: in function <...ddOns/ExRT_Reminder/Libs/LibOpenRaid/LibOpenRaid.lua:3343>
[C]: in function 'xpcall'
[ExRT_Reminder/Libs/LibOpenRaid/LibOpenRaid.lua]:744: in function <...ddOns/ExRT_Reminder/Libs/LibOpenRaid/LibOpenRaid.lua:726>

Locals:
playerName = "Deviatè"
ratingInfo = <table> {
 currentSeasonScore = 2160
 classID = 3
 runs = <table> {
 }
}
openRaidLib = <table> {
 publicCallback = <table> {
 }
 OpenNotesManager = <table> {
 }
 __errors = <table> {
 }
 UnitIDCache = <table> {
 }
 CooldownManager = <table> {
 }
 commHandler = <table> {
 }
 __version = 155
 internalCallback = <table> {
 }
 UnitInfoManager = <table> {
 }
 bHasEnteredWorld = true
 RatingInfoManager = <table> {
 }
 specAttribute = <table> {
 }
 cooldownManager = <table> {
 }
 commPrefixDeprecated = <table> {
 }
 AuraTracker = <table> {
 }
 playerInfoManager = <table> {
 }
 KeystoneInfoManager = <table> {
 }
 gearManager = <table> {
 }
 eventFunctions = <table> {
 }
 GearManager = <table> {
 }
 playerAlive = true
 mainControl = <table> {
 }
 Util = <table> {
 }
 inGroup = true
 Schedules = <table> {
 }
}
CONST_COMM_RATING_DATA_PREFIX = "M"
```