### PR TITLE
Properly handle addon messages sent through AceComm

### DIFF
--- a/LibOpenRaid.lua
+++ b/LibOpenRaid.lua
@@ -489,7 +489,15 @@ end
     openRaidLib.commHandler.eventFrame = CreateFrame("frame")
     openRaidLib.commHandler.eventFrame:RegisterEvent("CHAT_MSG_ADDON")
     openRaidLib.commHandler.eventFrame:RegisterEvent("CHAT_MSG_ADDON_LOGGED")
-    openRaidLib.commHandler.eventFrame:SetScript("OnEvent", openRaidLib.commHandler.OnReceiveComm)
+
+    local aceComm = LibStub:GetLibrary("AceComm-3.0", true)
+    if (aceComm) then
+        aceComm:RegisterComm(CONST_COMM_PREFIX, function(...)
+            openRaidLib.commHandler:OnReceiveComm("CHAT_MSG_ADDON", ...)
+        end)
+    else
+        openRaidLib.commHandler.eventFrame:SetScript("OnEvent", openRaidLib.commHandler.OnReceiveComm)
+    end
 
     openRaidLib.commHandler.commCallback = {
                                             --when transmiting


### PR DESCRIPTION
Fixes issue#67 as long as AceComm is loaded.

The logic in `sendData` is currently setup so all messages are _always_ sent through `AceComm` if available. Due to that we can simple replace the default `OnEvent` handler with their `RegisterComm` handler. This automatically takes care of merging together any split messages and presents them as one whole.

There's still an issue with sending large messages without `AceComm`. That requires more work as no messages are ever split, nor is there any logic to re-assemble them.