### PR TITLE
Adds Invigorating Healing Potion to All Potions collection.

### DIFF
--- a/ThingsToMantain_WarWithin.lua
+++ b/ThingsToMantain_WarWithin.lua
@@ -161,8 +161,9 @@ do
 
         --on use spell ids
 		LIB_OPEN_RAID_ALL_POTIONS = {
+			[1238009] = true, --Invigorating Healing Potion
 			[431419] = true, --Cavedweller's Delight
-			[431416] = true, --Healing Potion algari
+			[431416] = true, --Healing Potion Algari
 			[431914] = true, --Potion of Unwavering Focus
 			[431932] = true, --Tempered Potion
 			[453205] = true, --Potion Bomb of Power
@@ -180,7 +181,7 @@ do
 		--spellId of healing from potions
 		LIB_OPEN_RAID_HEALING_POTIONS = {
 			[1238009] = true, --Invigorating Healing Potion
-			[431416] = true, --Healing Potion algari
+			[431416] = true, --Healing Potion Algari
 			[431419] = true, --Cavedweller's Delight
 			[452767] = true, --Heartseeking Health Injector (engineering tinker)
 		}


### PR DESCRIPTION
Also corrected the capitalization of 'Algari' in potion IDs.

Why:
Invigorating Healing Potion is not being picked up in Details in the Healthstone & Health Pots view, nor in the Advanced Death Log Plugin. 