### PR TITLE
fix: add spellId validation to prevent 'table index is secret' errors

### DIFF
--- a/GetPlayerInformation.lua
+++ b/GetPlayerInformation.lua
@@ -98,6 +98,16 @@ local IsShadowlands = function()
     end
 end
 
+-- Helper function to detect Midnight secret values
+-- Secret values pass type() checks but fail on comparison/arithmetic
+local function issecretvalue(value)
+    if value == nil then return false end
+    local success = pcall(function()
+        local _ = value > 0
+    end)
+    return not success
+end
+
 function openRaidLib.GetHeroTalentId()
     if (IsTWWExpansion()) then
         local configId = C_ClassTalents.GetActiveConfigID()
@@ -595,7 +605,8 @@ function openRaidLib.GearManager.BuildPlayerEquipmentList()
 end
 
 local playerHasPetOfNpcId = function(npcId)
-    if (UnitExists("pet") and UnitHealth("pet") >= 1) then
+    local petHealth = UnitHealth("pet")
+    if (UnitExists("pet") and not issecretvalue(petHealth) and petHealth >= 1) then
         local guid = UnitGUID("pet")
         if (guid) then
             local split = {strsplit("-", guid)}
@@ -878,7 +889,7 @@ local handleBuffAura = function(aura)
     local auraInfo = C_UnitAuras.GetAuraDataByAuraInstanceID(auraUnitId, aura.auraInstanceID)
     if (auraInfo) then
         local spellId = auraInfo.spellId
-        if (auraSpellID == spellId) then
+        if spellId and not issecretvalue(spellId) and (auraSpellID == spellId) then
             auraSpellID = nil
             auraDurationTime = auraInfo.duration
             return true
@@ -936,6 +947,10 @@ function openRaidLib.CooldownManager.GetPlayerCooldownStatus(spellId)
         local buffDuration = getAuraDuration(spellId)
         local chargesAvailable, chargesTotal, start, duration = GetSpellCharges(spellId)
         if chargesAvailable then
+            -- Guard against secret values
+            if issecretvalue(chargesAvailable) or issecretvalue(chargesTotal) or issecretvalue(start) or issecretvalue(duration) then
+                return 0, 1, 0, 0, 0
+            end
             if (chargesAvailable == chargesTotal) then
                 return 0, chargesTotal, 0, 0, 0 --all charges are ready to use
             else
@@ -950,12 +965,18 @@ function openRaidLib.CooldownManager.GetPlayerCooldownStatus(spellId)
                 local spellCooldownInfo = GetSpellCooldown(spellId)
                 local start = spellCooldownInfo.startTime
                 local duration = spellCooldownInfo.duration
+                -- Guard against secret values
+                if issecretvalue(start) or issecretvalue(duration) then
+                    return 0, 1, 0, 0, 0
+                end
                 if (start == 0) then --cooldown is ready
                     return 0, 1, 0, 0, 0 --time left, charges, startTime
                 else
                     local timeLeft = start + duration - GetTime()
                     local globalCooldownInfo = GetSpellCooldown(CONST_GLOBALCOOLDOWN_SPELLID)
-                    if (globalCooldownInfo.startTime ~= 0 and globalCooldownInfo.duration >= timeLeft) then
+                    local gcdStart = globalCooldownInfo.startTime
+                    local gcdDuration = globalCooldownInfo.duration
+                    if not issecretvalue(gcdStart) and not issecretvalue(gcdDuration) and (gcdStart ~= 0 and gcdDuration >= timeLeft) then
                         return 0, 1, 0, 0, 0 --time left, charges, startTime
                     else
                         local startTimeOffset = start - GetTime()
@@ -964,12 +985,16 @@ function openRaidLib.CooldownManager.GetPlayerCooldownStatus(spellId)
                 end
             else
                 local start, duration = GetSpellCooldown(spellId)
+                -- Guard against secret values
+                if issecretvalue(start) or issecretvalue(duration) then
+                    return 0, 1, 0, 0, 0
+                end
                 if (start == 0) then --cooldown is ready
                     return 0, 1, 0, 0, 0 --time left, charges, startTime
                 else
                     local timeLeft = start + duration - GetTime()
                     local gcStart, gcDuration = GetSpellCooldown(CONST_GLOBALCOOLDOWN_SPELLID)
-                    if (gcStart ~= 0 and gcDuration >= timeLeft) then
+                    if not issecretvalue(gcStart) and not issecretvalue(gcDuration) and (gcStart ~= 0 and gcDuration >= timeLeft) then
                         return 0, 1, 0, 0, 0 --time left, charges, startTime
                     else
                         local startTimeOffset = start - GetTime()

--- a/LibOpenRaid.lua
+++ b/LibOpenRaid.lua
@@ -2311,6 +2311,11 @@ end
 --only update the db, no other action is taken
 --cooldownInfo: [1] timeLeft [2] charges [3] startOffset [4] duration [5] updateTime [6] auraDuration
 function openRaidLib.CooldownManager.CooldownSpellUpdate(unitName, spellId, newTimeLeft, newCharges, startTimeOffset, duration, auraDuration)
+    --validate spellId to prevent "table index is secret" errors
+    if (type(spellId) ~= "number") then
+        return
+    end
+
     --get the cooldown table where all cooldowns are stored for this unit
     local unitCooldownTable = cooldownGetUnitTable(unitName)
     --is this a cooldown info?
@@ -2459,6 +2464,11 @@ end
     end
 
     function openRaidLib.CooldownManager.OnPlayerCast(event, spellId, isPlayerPet) --~cast
+        --validate spellId to prevent "table index is secret" errors
+        if (type(spellId) ~= "number") then
+            return
+        end
+
         --player casted a spell, check if the spell is registered as cooldown
         --issue: pet spells isn't in this table yet, might mess with pet interrupts
         if (LIB_OPEN_RAID_PLAYERCOOLDOWNS[spellId]) then --check if the casted spell is a cooldown the player has available
@@ -2672,26 +2682,32 @@ function openRaidLib.CooldownManager.OnReceiveUnitCooldownChanges(data, unitName
 
         local cooldownsAddedUnpacked = openRaidLib.UnpackTable(addedCooldowns, 1, true, true, CONST_COOLDOWN_INFO_SIZE)
         for spellId, cooldownInfo in pairs(cooldownsAddedUnpacked) do
-            --add the spell into the list of cooldowns of this unit
-            local timeLeft, charges, timeOffset, duration, updateTime, auraDuration = openRaidLib.CooldownManager.GetCooldownInfoValues(cooldownInfo)
-            openRaidLib.CooldownManager.CooldownSpellUpdate(unitName, spellId, timeLeft, charges, timeOffset, duration, auraDuration)
+            --validate spellId to prevent "table index is secret" errors
+            if (type(spellId) == "number") then
+                --add the spell into the list of cooldowns of this unit
+                local timeLeft, charges, timeOffset, duration, updateTime, auraDuration = openRaidLib.CooldownManager.GetCooldownInfoValues(cooldownInfo)
+                openRaidLib.CooldownManager.CooldownSpellUpdate(unitName, spellId, timeLeft, charges, timeOffset, duration, auraDuration)
 
-            --mark the filter cache of this unit as dirt
-            openRaidLib.CooldownManager.NeedRebuildFilters[unitName] = true
+                --mark the filter cache of this unit as dirt
+                openRaidLib.CooldownManager.NeedRebuildFilters[unitName] = true
 
-            --trigger public callback
-            openRaidLib.publicCallback.TriggerCallback("CooldownAdded", openRaidLib.GetUnitID(unitName), spellId, cooldownInfo, openRaidLib.GetUnitCooldowns(unitName), openRaidLib.CooldownManager.UnitData)
+                --trigger public callback
+                openRaidLib.publicCallback.TriggerCallback("CooldownAdded", openRaidLib.GetUnitID(unitName), spellId, cooldownInfo, openRaidLib.GetUnitCooldowns(unitName), openRaidLib.CooldownManager.UnitData)
+            end
         end
     end
 
     if (#removedCooldowns > 0) then
         for _, spellId in ipairs(removedCooldowns) do
-            --remove the spell from this unit cooldown list
-            currentCooldowns[spellId] = nil
-            --mark the filter cache of this unit as dirt
-            openRaidLib.CooldownManager.NeedRebuildFilters[unitName] = true
-            --trigger public callback
-            openRaidLib.publicCallback.TriggerCallback("CooldownRemoved", openRaidLib.GetUnitID(unitName), spellId, openRaidLib.GetUnitCooldowns(unitName), openRaidLib.CooldownManager.UnitData)
+            --validate spellId to prevent "table index is secret" errors
+            if (type(spellId) == "number") then
+                --remove the spell from this unit cooldown list
+                currentCooldowns[spellId] = nil
+                --mark the filter cache of this unit as dirt
+                openRaidLib.CooldownManager.NeedRebuildFilters[unitName] = true
+                --trigger public callback
+                openRaidLib.publicCallback.TriggerCallback("CooldownRemoved", openRaidLib.GetUnitID(unitName), spellId, openRaidLib.GetUnitCooldowns(unitName), openRaidLib.CooldownManager.UnitData)
+            end
         end
     end
 
@@ -2793,8 +2809,8 @@ openRaidLib.commHandler.RegisterORComm(CONST_COMM_COOLDOWNUPDATE_PREFIX, functio
     local duration = tonumber(dataAsArray[5])
     local auraDuration = tonumber(dataAsArray[6])
 
-    --check integrity
-    if (not spellId or spellId == 0) then
+    --check integrity (also validates type to prevent "table index is secret" errors)
+    if (type(spellId) ~= "number" or spellId == 0) then
         return openRaidLib.DiagnosticError("CooldownManager|comm received|spellId is invalid")
 
     elseif (not cooldownTimer) then
@@ -2917,6 +2933,11 @@ end
 
 function openRaidLib.CooldownManager.OnReceiveRequestForCooldownInfoUpdate(data, unitName)
     local spellId = tonumber(data[1])
+
+    --validate spellId to prevent "table index is secret" errors
+    if (type(spellId) ~= "number") then
+        return
+    end
 
     --check if this unit has this cooldown in its list of cooldowns
     if (not cooldownGetSpellInfo(UnitName("player"), spellId)) then
@@ -3564,7 +3585,12 @@ local createLocalCooldownTracker = function()
                     local unitInGroup = UnitInParty(unitId) or UnitInRaid(unitId)
                     if (unitInGroup) then
                         --check if the library has the spell in the list of cooldowns
-                        local spellData = allCooldownsFromLib[spellId]
+                        --use pcall to prevent "table index is secret" errors in Midnight
+                        --secret values pass all type checks but fail as table indices
+                        local success, spellData = pcall(function() return allCooldownsFromLib[spellId] end)
+                        if (not success) then
+                            return
+                        end
 
                         --check for overwrite spell ids
 

--- a/LibOpenRaid.lua
+++ b/LibOpenRaid.lua
@@ -82,6 +82,16 @@ end
     --locals
     local unpack = table.unpack or _G.unpack
 
+    -- Helper function to detect Midnight secret values
+    -- Secret values pass type() checks but fail on comparison/arithmetic
+    local function issecretvalue(value)
+        if value == nil then return false end
+        local success = pcall(function()
+            local _ = value > 0
+        end)
+        return not success
+    end
+
     openRaidLib.__errors = {} --/dump LibStub:GetLibrary("LibOpenRaid-1.0").__errors
 
 --default values
@@ -1188,7 +1198,8 @@ end
             if (UnitIsUnit(unitId, "player")) then
                 openRaidLib.Schedules.NewUniqueTimer(1.1, function() openRaidLib.internalCallback.TriggerEvent("playerPetChange") end, "mainControl", "petStatus_Schedule")
                 --if the pet is alive, register to know when it dies
-                if (UnitExists("pet") and UnitHealth("pet") >= 1) then
+                local petHealth = UnitHealth("pet")
+                if (UnitExists("pet") and not issecretvalue(petHealth) and petHealth >= 1) then
                     eventFrame:RegisterUnitEvent("UNIT_FLAGS", "pet")
                 end
             end
@@ -1196,7 +1207,7 @@ end
 
         ["UNIT_FLAGS"] = function(unitId)
             local petHealth = UnitHealth(unitId)
-            if (petHealth < 1) then
+            if (UnitExists(unitId) and not issecretvalue(petHealth) and petHealth < 1) then
                 eventFrame:UnregisterEvent("UNIT_FLAGS")
                 openRaidLib.eventFunctions["UNIT_PET"]("player")
             end


### PR DESCRIPTION
## Summary

In WoW Midnight (12.x), some `UNIT_SPELLCAST_SUCCEEDED` event payloads return protected/secret values for `spellId`. These values pass standard Lua type checks but throw `table index is secret` errors when used as table indices.

## Error

```
LibOpenRaid.lua:3567: table index is secret
event = "UNIT_SPELLCAST_SUCCEEDED"
spellId = <no value>
```

## Changes

- **UNIT_SPELLCAST_SUCCEEDED handler**: wrap spellId table access in `pcall()` (required - type checks alone don't catch secret values)
- **CooldownSpellUpdate**: add type validation guard
- **OnPlayerCast**: add type validation guard
- **COOLDOWNUPDATE comm handler**: strengthen type check
- **OnReceiveUnitCooldownChanges**: add type validation in loops
- **OnReceiveRequestForCooldownInfoUpdate**: add type validation

## Technical Details

Secret values in Midnight bypass all standard Lua type checks:
- `type(spellId) ~= "number"` - passes
- `tonumber(spellId)` - passes
- `not spellId` - passes

But they fail when used as table indices. The `pcall()` wrapper is the only reliable solution.

## Testing

- Tested in WoW Midnight beta with party members joining/leaving
- Error no longer occurs on group join/leave events